### PR TITLE
fix code tag's text color inside mark tag

### DIFF
--- a/dist/tailwind.css
+++ b/dist/tailwind.css
@@ -1049,6 +1049,10 @@ a code {
   color: var(--tw-prose-links);
 }
 
+mark code {
+  color: inherit;
+}
+
 strong {
   color: var(--tw-prose-bold);
   font-weight: 600;


### PR DESCRIPTION
Code tag renders white color text in dark mode, it looks unclear when it lies inside a mark tag (inside a highlight markdown syntax).

<img width="568" alt="CleanShot 2022-11-20 at 17 57 57@2x" src="https://user-images.githubusercontent.com/17041194/202895899-222e2869-1ec9-4bd4-9c04-5bee2f2cd0c5.png">

I fixed the style by simple add a inherit property for code inside mark block

```css
mark code {
  color: inherit;
}
```